### PR TITLE
Restore interrupts when there are non-zero exits codes in the child process

### DIFF
--- a/proc_parent.go
+++ b/proc_parent.go
@@ -136,6 +136,9 @@ func (mp *parent) handleSignal(s os.Signal) {
 	//while the child process is running, proxy
 	//all signals through
 	if mp.childCmd != nil && mp.childCmd.Process != nil {
+		if s == os.Interrupt {
+			mp.Supervise = false
+		}
 		if s.String() != "urgent I/O condition" {
 			mp.debugf("proxying signal (%s)", s)
 		}


### PR DESCRIPTION
Disable supervise mode when a os.Interrupt is received to preserve ctrl+c behavior when there is a non-zero exit code.