### PR TITLE
Ignore SIGURG during shutdown

### DIFF
--- a/proc_parent.go
+++ b/proc_parent.go
@@ -156,7 +156,9 @@ func (mp *parent) sendSignal(s os.Signal) {
 	if mp.childCmd != nil && mp.childCmd.Process != nil {
 		if err := mp.childCmd.Process.Signal(s); err != nil {
 			mp.debugf("signal (%s) failed (%s), assuming child process died unexpectedly", s, err)
-			if !mp.Supervise {
+			//if we receive a SIGURG during shutdown
+			//don't exit with an error code
+			if !mp.Supervise && s.String() != "urgent I/O condition" {
 				os.Exit(1)
 			}
 		}

--- a/proc_parent.go
+++ b/proc_parent.go
@@ -136,7 +136,7 @@ func (mp *parent) handleSignal(s os.Signal) {
 		if s == os.Interrupt {
 			mp.Supervise = false
 		}
-		if s.String() != "urgent I/O condition" {
+		if s != syscall.SIGURG {
 			mp.debugf("proxying signal (%s)", s)
 		}
 		mp.sendSignal(s)
@@ -146,7 +146,7 @@ func (mp *parent) handleSignal(s os.Signal) {
 		mp.debugf("interupt with no child")
 		os.Exit(1)
 	} else {
-		if s.String() != "urgent I/O condition" {
+		if s != syscall.SIGURG {
 			mp.debugf("signal discarded (%s), no child process", s)
 		}
 	}
@@ -158,7 +158,7 @@ func (mp *parent) sendSignal(s os.Signal) {
 			mp.debugf("signal (%s) failed (%s), assuming child process died unexpectedly", s, err)
 			//if we receive a SIGURG during shutdown
 			//don't exit with an error code
-			if !mp.Supervise && s.String() != "urgent I/O condition" {
+			if !mp.Supervise && s != syscall.SIGURG {
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
This technically applies whenever there isn't a child process running. But in practice we've only seen it during shutdown. Also the `SIGURG` is likely caused by [gos internal scheduling](https://github.com/golang/go/issues/37942), rather than something we'd actually need to handle.